### PR TITLE
Add contract to exercise failure cases

### DIFF
--- a/contracts/failures/CMakeLists.txt
+++ b/contracts/failures/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(failures failures.cpp)
+
+target_link_libraries(failures koinos_proto_embedded koinos_api koinos_api_cpp koinos_wasi_api c c++ c++abi clang_rt.builtins-wasm32)

--- a/contracts/failures/failures.cpp
+++ b/contracts/failures/failures.cpp
@@ -1,0 +1,65 @@
+#include <koinos/system/system_calls.hpp>
+#include <stdio.h>
+using namespace koinos;
+
+int main()
+{
+   auto [ entry_point, args ] = system::get_arguments();
+
+   std::array< uint8_t, 2048 > retbuf;
+
+   koinos::read_buffer rdbuf( (uint8_t*)args.c_str(), args.size() );
+   koinos::write_buffer buffer( retbuf.data(), retbuf.size() );
+
+   switch( entry_point )
+   {
+      // Divide by 0
+      case 0x01:
+      {
+         system::log( "divide by zero" );
+         volatile uint64_t a = 10;
+         volatile uint64_t b = 0;
+         system::log( std::to_string( a/b ) );
+         break;
+      }
+      // Allocate too much memory (4GB+)
+      case 0x02:
+      {
+         system::log( "allocate more than 4GB" );
+         size_t allocSize = size_t(5) * size_t(1024) * size_t(1024) * size_t(1024);
+         uint8_t* val = (uint8_t*)malloc( allocSize );
+         char s[256];
+         snprintf( s, sizeof( s ), "pointer: %p\n", (void*)val );
+         system::log( std::string{ s } );
+         memset( val, 1, sizeof(uint8_t) * allocSize);
+         break;
+      }
+      // Infinite loop
+      case 0x03:
+      {
+         while(1) {}
+         break;
+      }
+      // Running out of stack
+      case 0x04:
+      {
+         system::call( system::get_contract_id(), entry_point, std::string{} );
+         break;
+      }
+      // Test behavior of floating point
+      case 0x05:
+      {
+         float x = 1.3f;
+         double y = 1.3f;
+         system::log( std::to_string( x * y ) );
+         break;
+      }
+      default:
+         system::revert( "unknown entry point" );
+   }
+
+   system::result r;
+   r.mutable_object().set( buffer.data(), buffer.get_size() );
+
+   system::exit( 0, r );
+}

--- a/contracts/failures/failures.cpp
+++ b/contracts/failures/failures.cpp
@@ -1,6 +1,13 @@
 #include <koinos/system/system_calls.hpp>
-#include <stdio.h>
+#include <limits>
 using namespace koinos;
+
+void foo( uint64_t x )
+{
+   static uint64_t y = 0;
+   y += x;
+   foo( x );
+}
 
 int main()
 {
@@ -40,14 +47,20 @@ int main()
          while(1) {}
          break;
       }
-      // Running out of stack
+      // Running out of execution context stack overflow
       case 0x04:
       {
          system::call( system::get_contract_id(), entry_point, std::string{} );
          break;
       }
-      // Test behavior of floating point
+      // Running out of VM stack
       case 0x05:
+      {
+         foo( 1 );
+         break;
+      }
+      // Test behavior of floating point
+      case 0x06:
       {
          float x = 1.3f;
          double y = 1.3f;


### PR DESCRIPTION
Resolves #68.

## Brief description
Adds a smart contract to exercise failure cases.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
=== RUN   TestFailures
    failures_test.go:17: Generating key for failures
    integration.go:582: Waiting 1s for chain to be ready...
    integration.go:582: Waiting 2s for chain to be ready...
    integration.go:582: Waiting 4s for chain to be ready...
    integration.go:582: Waiting 5s for chain to be ready...
    integration.go:582: Waiting 5s for chain to be ready...
    failures_test.go:23: Uploading failures contract
    failures_test.go:31: Entry: 1
    failures_test.go:33: Error: module exited due to trap
    failures_test.go:31: Entry: 2
    failures_test.go:33: Error: module exited due to trap
    failures_test.go:31: Entry: 3
    failures_test.go:33: Error: An internal server error has occurred
    failures_test.go:31: Entry: 4
    failures_test.go:33: Error: apply context stack overflow
    failures_test.go:31: Entry: 5
    failures_test.go:33: Error: module exited due to trap
--- PASS: TestFailures (18.56s)
PASS
ok  	koinos-integration-tests/tests/failures	18.717s
```
