### PR TITLE
Pass contract arguments to check_authority

### DIFF
--- a/contracts/koin/koin.cpp
+++ b/contracts/koin/koin.cpp
@@ -92,6 +92,8 @@ enum entries : uint32_t
    burn_entry               = 0x859facc5
 };
 
+std::string arguments; // Declared globally to pass to check_authority
+
 using get_account_rc_arguments
    = chain::get_account_rc_arguments<
       constants::max_name_size
@@ -222,7 +224,7 @@ token::transfer_result transfer( const token::transfer_arguments< constants::max
       system::fail( "cannot transfer to self" );
 
    const auto [ caller, privilege ] = system::get_caller();
-   if ( caller != from && !system::check_authority( from ) )
+   if ( caller != from && !system::check_authority( from, arguments ) )
       system::fail( "from has not authorized transfer", chain::error_code::authorization_failure );
 
    token::mana_balance_object from_bal_obj;
@@ -316,7 +318,7 @@ token::burn_result burn( const token::burn_arguments< constants::max_address_siz
    uint64_t value = args.get_value();
 
    const auto [ caller, privilege ] = system::get_caller();
-   if ( caller != from && !system::check_authority( from ) )
+   if ( caller != from && !system::check_authority( from, arguments ) )
       system::fail( "from has not authorized burn", chain::error_code::authorization_failure );
 
    token::mana_balance_object from_bal_obj;
@@ -360,11 +362,12 @@ token::burn_result burn( const token::burn_arguments< constants::max_address_siz
 
 int main()
 {
-   auto [entry_point, args] = system::get_arguments();
+   uint32_t entry_point;
+   std::tie( entry_point, arguments ) = system::get_arguments();
 
    std::array< uint8_t, constants::max_buffer_size > retbuf;
 
-   koinos::read_buffer rdbuf( (uint8_t*)args.c_str(), args.size() );
+   koinos::read_buffer rdbuf( (uint8_t*)arguments.c_str(), arguments.size() );
    koinos::write_buffer buffer( retbuf.data(), retbuf.size() );
 
    switch( std::underlying_type_t< entries >( entry_point ) )


### PR DESCRIPTION
Resolves #70.

## Brief description
Passes the contract argument to `check_authority` calls.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
=== RUN   TestKoin
    koin_test.go:16: Generating key for alice
    koin_test.go:20: Generating key for bob
    integration.go:612: Waiting 1s for chain to be ready...
    integration.go:612: Waiting 2s for chain to be ready...
    integration.go:612: Waiting 4s for chain to be ready...
    integration.go:612: Waiting 5s for chain to be ready...
    koin_test.go:31: Uploading KOIN contract
    koin_test.go:35: Minting 1000 satoshis to alice
    koin_test.go:45: Fail to transfer 1001 satoshi from alice to bob
    koin_test.go:60: Fail to overflow 64-bit unsigned integer during mint
    koin_test.go:75: Fail to burn more than balance
    koin_test.go:93: Transferring 500 satoshi from alice to bob
    koin_test.go:97: Ensuring total supply remains unchanged
    koin_test.go:103: Minting 500 satoshis to bob
    koin_test.go:110: Ensuring total supply is 1500
    koin_test.go:113: Asserting alice's balance is 500
    koin_test.go:119: Asserting bob's balance is 1000
    koin_test.go:125: Burning 100 satoshi from bob's balance
    koin_test.go:130: Ensuring total supply is 1400
    koin_test.go:136: Asserting bob's balance is 900
--- PASS: TestKoin (13.16s)
PASS
```